### PR TITLE
install.ps1 fixes for #1554

### DIFF
--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -46,7 +46,7 @@ try {
     $val = $envKey.GetValue("PATH", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames);
     if ($val -notlike "*${binRoot};*") {
         $envKey.SetValue("PATH", "$binRoot;$val", [Microsoft.Win32.RegistryValueKind]::ExpandString);
-        Write-Host "Added $binRoot to the `$PATH (changes may not be visible untill after a restart)"
+        Write-Host "Added $binRoot to the `$PATH (changes may not be visible until after a restart)"
     }
     $envKey.Close();
 } catch { 
@@ -54,7 +54,7 @@ try {
 }
 
 if ($env:PATH -notlike "*$binRoot*") {
-    $env:PATH = $binRoot;$env:PATH
+    $env:PATH = "$binRoot;$env:PATH"
 }
 
 # And cleanup our temp files


### PR DESCRIPTION
Fixes the quoting for the value assigned to $env:PATH and a small typo in one of the messages.